### PR TITLE
add dutch domain

### DIFF
--- a/Bypass studocu paywall.user.js
+++ b/Bypass studocu paywall.user.js
@@ -4,6 +4,7 @@
 // @version      1.01
 // @description  try to take over the world!
 // @author       https://github.com/lambwheit
+// @match        https://studeersnel.nl/*
 // @match        https://www.studocu.com/*
 // @icon         https://www.google.com/s2/favicons?domain=studocu.com
 // ==/UserScript==


### PR DESCRIPTION
Adds the Dutch "version" of Studocu, `studeersnel.nl`. Everything on this domain is the same, including the paywall. Only difference is a different domain to cater to Dutch people specifically. 
These domains may exist for other countries as well, but was not able to find a list these domains.

Probably needs a version number increment to allow for userscript managers to update, something like `v1.0.2`?